### PR TITLE
change active nav element styling to backend, fix double loading of p…

### DIFF
--- a/srcs/backend/transcendence/srcs/app/play.py
+++ b/srcs/backend/transcendence/srcs/app/play.py
@@ -59,6 +59,7 @@ def playContext(request, error, success):
         in_active_tournament = False
 
     context = {
+        'active': "play",
         'current_user': current_user,
         'inviteform': inviteform,
         'playform': playform,

--- a/srcs/backend/transcendence/srcs/app/user/profile.py
+++ b/srcs/backend/transcendence/srcs/app/user/profile.py
@@ -28,6 +28,7 @@ def get_profile_details(username:str, self:bool) -> dict:
 def profileContext(username:str, self:bool) -> dict:
     logger.debug('in profileContext')
     context = {}
+    context["active"] = "profile"
     context["friends"] = friendsContext(username, None, None)
     context["details"] = get_profile_details(username, self)
     context["name_form"] = UpdateNameForm()

--- a/srcs/backend/transcendence/srcs/templates/base.html
+++ b/srcs/backend/transcendence/srcs/templates/base.html
@@ -1,5 +1,5 @@
 <div>
-	{% include 'partials/navbar_full.html' with current_user=current_user %}
+	{% include 'partials/navbar_full.html' with current_user=current_user active=active %}
 	{% block content %}
 	{% endblock %}
 	{% comment %} maybe add in the chat here {% endcomment %}

--- a/srcs/backend/transcendence/srcs/templates/partials/navbar_full.html
+++ b/srcs/backend/transcendence/srcs/templates/partials/navbar_full.html
@@ -8,10 +8,33 @@
 		<div class="collapse navbar-collapse justify-content-md-end" id="navbarSupportedContent">
 			<ul class="navbar-nav ml-auto">
 				<!-- The items of the nav component -->
-				<li class="nav-item"> <a href="/play" class="nav-link" onclick="setActive(this)">Play</a></li>
-				<li class="nav-item"> <a id="profileLinkTag" href="/profile/{{current_user}}" class="nav-link" onclick="setActive(this)">My Profile</a></li>
-				<li class="nav-item"> <button type="submit" id="logoutButton" class="btn btn-primary">Logout</button></li>
-			</ul>
+				{% if active == "play" %}
+				<li class="nav-item ms-3"> <a href="/play" class="nav-link">
+					<span class="text-success">
+						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-fill" viewBox="0 0 16 16">
+							<path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
+						</svg>
+					</span>
+					Play
+				</a></li>
+				<li class="nav-item ms-3"> <a href="/profile/{{current_user}}" class="nav-link">My Profile</a></li>
+				<li class="nav-item ms-3"> <button type="submit" id="logoutButton" class="btn btn-primary">Logout</button></li>
+				{% elif active == "profile" %}
+				<li class="nav-item ms-3"> <a href="/play" class="nav-link">Play</a></li>
+				<li class="nav-item ms-3"> <a href="/profile/{{current_user}}" class="nav-link">
+					<span class="text-success">
+						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-fill" viewBox="0 0 16 16">
+							<path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
+						</svg>
+					</span>
+					My Profile
+				</a></li>
+				<li class="nav-item ms-3"> <button type="submit" id="logoutButton" class="btn btn-primary">Logout</button></li>
+				{% else %}
+				<li class="nav-item ms-3"> <a href="/play" class="nav-link">Play</a></li>
+				<li class="nav-item ms-3"> <a href="/profile/{{current_user}}" class="nav-link">My Profile</a></li>
+				<li class="nav-item ms-3"> <button type="submit" id="logoutButton" class="btn btn-primary">Logout</button></li>
+				{% endif %}
 		</div>
 	</div>
 </nav>

--- a/srcs/backend/transcendence/srcs/templates/user/play.html
+++ b/srcs/backend/transcendence/srcs/templates/user/play.html
@@ -54,7 +54,10 @@
 						<ul class="list-group list-group-flush">	
 							{% for invite in invites_sent %}
 								<li class="list-group-item h6 pe-5">
-									Challenged <a id="profileLinkTag" href="/profile/{{ invite.p2.username }}" >{{ invite.p2.username }}</a> to <b>{{ invite.game }}</b>
+									Challenged 
+									<nav>
+										<a href="/profile/{{ invite.p2.username }}" >{{ invite.p2.username }}</a> to <b>{{ invite.game }}</b>
+									</nav>	
 									<button type="submit" id="gameRequestButton" data-from-user={{ invite.p2.username }} data-action="cancel" class="btn btn-danger btn-sm">Cancel</button>
 								</li>
 							{% endfor %}
@@ -62,7 +65,9 @@
 						<ul class="list-group list-group-flush">	
 							{% for invite in invites_received %}
 								<li class="list-group-item h6 pe-5">
-									<a id="profileLinkTag" href="/profile/{{ invite.p1.username }}" >{{ invite.p1.username }}</a> challenged you to <b>{{ invite.game }}</b>
+									<nav>
+										<a href="/profile/{{ invite.p1.username }}" >{{ invite.p1.username }}</a> challenged you to <b>{{ invite.game }}</b>
+									</nav>
 									<button type="submit" id="gameRequestButton" data-from-user={{ invite.p1.username }} data-action="accept" class="btn btn-primary btn-sm">✓</button> or
 									<button type="submit" id="gameRequestButton" data-from-user={{ invite.p1.username }} data-action="reject" class="btn btn-danger btn-sm">✗</button>
 								</li>
@@ -135,7 +140,12 @@
 
 							{% if my_participant.status == 'Pending' %} {% comment %} We have not confirmed attendance yet {% endcomment %}
 							<div>
-								<p class="h5 pt-3 "><a id="profileLinkTag" href="/profile/{{ tournament_in.creator.username }}" >{{ tournament_in.creator.username }}</a> invited you to a {{ tournament_in.game }} tournament!</p>
+								<p class="h5 pt-3 ">
+									<nav>
+										<a href="/profile/{{ tournament_in.creator.username }}" >{{ tournament_in.creator.username }}</a> invited you to a {{ tournament_in.game }} 
+									</nav>
+									tournament!
+								</p>
 								<form id="tournamentJoinForm">
 									{% csrf_token %}
 									<input type="hidden" name="participant_id" value={{ my_participant.id }}>
@@ -159,7 +169,9 @@
 											{% if current_user == participant.user%}
 											{{ participant.user.username }}
 											{% else %}
-											<a id="profileLinkTag" href="/profile/{{ participant.user.username }}" >{{ participant.user.username }}</a>
+											<nav>
+												<a href="/profile/{{ participant.user.username }}" >{{ participant.user.username }}</a>
+											</nav>
 											{% endif %}
 											as {{ participant.alias }}   Status: {% if participant.status == "Accepted" %}<p class="text-success d-inline">{{ participant.status }}</p>{% else %}<p class="text-warning d-inline">{{ participant.status }}{% endif %}
 											{% if participant.user == current_user and current_user != tournament_in.creator%}

--- a/srcs/backend/transcendence/srcs/templates/user/profile_partials/friends.html
+++ b/srcs/backend/transcendence/srcs/templates/user/profile_partials/friends.html
@@ -54,7 +54,9 @@
 			<ul class="list-group list-group-flush">
 				{% for invite in friends.in_invites %}
 					<li class="list-group-item h5">
-						<a class="pe-5" id="profileLinkTag" href="/profile/{{ invite.from_user.username }}" >{{ invite.from_user.username }}</a>
+						<nav>
+							<a class="pe-5" href="/profile/{{ invite.from_user.username }}" >{{ invite.from_user.username }}</a>
+						</nav>
 						<button type="submit" id="friendRequestButton" data-from-user={{ invite.from_user.username }} data-action="accept" class="btn btn-primary btn-sm">Accept</button>
 						<button type="submit" id="friendRequestButton" data-from-user={{ invite.from_user.username }} data-action="reject" class="btn btn-danger btn-sm">Reject</button>
 					</li>
@@ -85,7 +87,9 @@
 			<ul class="list-group list-group-flush">
 				{% for invite in friends.out_invites %}
 					<li class="list-group-item pe-5 text-secondary">
-						<a class="h5 text-black" id="profileLinkTag" href="/profile/{{ invite.to_user.username }}" >{{ invite.to_user.username }}</a> 
+						<nav>
+							<a class="h5 text-black" href="/profile/{{ invite.to_user.username }}" >{{ invite.to_user.username }}</a> 
+						</nav>
 						Friend request pending...
 					</li>
 				{% endfor %}
@@ -93,7 +97,9 @@
 				{% for friendship in friends.friendships %}
 					{% if friends.current_user == friendship.to_user %}
 						<li class="list-group-item h5 pe-5">
-							<a id="profileLinkTag" href="/profile/{{ friendship.from_user.username }}" >{{ friendship.from_user.username }}</a> 
+							<nav>
+								<a href="/profile/{{ friendship.from_user.username }}" >{{ friendship.from_user.username }}</a> 
+							</nav>
 							{% if friendship.from_user.is_online %}
 							<span class="text-success" id="online_status">
 								<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-emoji-laughing-fill" viewBox="0 0 16 16">
@@ -111,7 +117,9 @@
 						</li>
 					{% else %}
 						<li class="list-group-item h5 pe-5">
-							<a id="profileLinkTag" href="/profile/{{friendship.to_user.username}}" >{{ friendship.to_user.username }}</a> 
+							<nav>
+								<a href="/profile/{{friendship.to_user.username}}" >{{ friendship.to_user.username }}</a> 
+							</nav>
 							{% if friendship.to_user.is_online %}
 							<span class="text-success" id="online_status">
 								<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-emoji-laughing-fill" viewBox="0 0 16 16">
@@ -138,7 +146,9 @@
 				{% for friendship in friends.friendships %}
 					{% if friends.current_user == friendship.to_user %}
 						<li class="list-group-item h5 pe-5">
-							<a id="profileLinkTag" href="/profile/{{friendship.from_user.username}}" >{{ friendship.from_user.username }}</a>
+							<nav>
+								<a href="/profile/{{friendship.from_user.username}}" >{{ friendship.from_user.username }}</a>
+							</nav>
 							{% if friendship.from_user.is_online %}
 							<span class="text-success" id="online_status">
 								<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-emoji-laughing-fill" viewBox="0 0 16 16">
@@ -155,7 +165,9 @@
 						</li>
 					{% else %}
 						<li class="list-group-item h5 pe-5">
-							<a id="profileLinkTag" href="/profile/{{friendship.to_user.username}}" >{{ friendship.to_user.username }}</a> 
+							<nav>
+								<a href="/profile/{{friendship.to_user.username}}" >{{ friendship.to_user.username }}</a> 
+							</nav>
 							{% if friendship.to_user.is_online %}
 							<span class="text-success" id="online_status">
 								<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-emoji-laughing-fill" viewBox="0 0 16 16">

--- a/srcs/backend/transcendence/srcs/templates/user/register.html
+++ b/srcs/backend/transcendence/srcs/templates/user/register.html
@@ -3,6 +3,16 @@
 		{% include 'partials/navbar_empty.html' %}
 	</div>
 	<div class="container" style="margin-top: 50px;">
+
+		<nav><button class="btn btn-primary"><a href="/login" class="nav-link">
+			<span class="text-white pe-2">
+				<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-skip-backward-fill" viewBox="0 0 16 16">
+					<path d="M.5 3.5A.5.5 0 0 0 0 4v8a.5.5 0 0 0 1 0V8.753l6.267 3.636c.54.313 1.233-.066 1.233-.697v-2.94l6.267 3.636c.54.314 1.233-.065 1.233-.696V4.308c0-.63-.693-1.01-1.233-.696L8.5 7.248v-2.94c0-.63-.692-1.01-1.233-.696L1 7.248V4a.5.5 0 0 0-.5-.5"/>
+				</svg>
+			</span>
+			Login
+		</a></button></nav>
+
 		<div class="row">
 			<div class="col">
 				<h2 class="d-flex justify-content-center mb-3 text-white">{{title | title}}</h2>

--- a/srcs/frontend/srcs/css/styles.css
+++ b/srcs/frontend/srcs/css/styles.css
@@ -110,6 +110,8 @@ body {
     display: block;
 }
 
+/* Nav item styling  */
+
 .nav-item {
     /* padding-left: 15px; */
     margin-top: 10px;
@@ -125,22 +127,21 @@ body {
     text-decoration: none;
 }
 
-.nav-link.active::before {
-    content: "> ";
-    color: rgba(29, 220, 108, 0.682);
-    pointer-events: none;
-}
-
 .nav-link:active {
     background-color: rgba(23, 162, 184, 0.5);
-    /* /* color: #fff; */
-    color:rgba(40, 89, 195, 0.5);
-    /* transition: color 0.3s; */
+    color: #fff;
 }
 
-.nav-link:focus {
-    outline: none; /* Remove the default focus outline */
+.nav-link:visited {
+    color: #ffffff;
 }
+
+/* Remove the default focus outline */
+.nav-link:focus {
+    outline: none; 
+}
+
+/*  content styling  */
 
 .main-content {
     /* box-sizing: border-box; */

--- a/srcs/frontend/srcs/js/index.js
+++ b/srcs/frontend/srcs/js/index.js
@@ -5,29 +5,6 @@ import { startScreenColorwar} from './colorwar.js'
 const loginEvent  = new Event("login");
 const logoutEvent = new Event("logout");
 
-document.addEventListener("DOMContentLoaded", function () {
-	// Get the current URL path
-	var currentPath = window.location.pathname;
-
-	// Find the link corresponding to the current URL path
-	var activeLink = document.querySelector('.nav-link[href="' + currentPath + '"]');
-
-	// If a matching link is found, add 'active' class to it
-	if (activeLink) {
-		activeLink.classList.add('active');
-	}
-});
-
-function setActive(link) {
-	var links = document.querySelectorAll('.nav-link');
-	links.forEach(function (el) {
-		el.classList.remove('active');
-	});
-	link.classList.add('active');
-}
-
-window.setActive = setActive;
-
 // Once we are using templates, we should include a csrftoken in django. Then django will be very happy and there is no need for decorator.
 function getCookie(name) {
     let cookieValue = null;
@@ -107,7 +84,6 @@ function updateEventListeners() {
     var addFriendButton = document.getElementById('addFriendButton');
     var blockUserButton = document.getElementById('blockUserButton');
     var friendRequestButtons = document.querySelectorAll('[id^="friendRequestButton"]');
-    var profileLinks = document.querySelectorAll('#profileLinkTag');
     var gameInviteForm = document.getElementById('gameInviteForm'); 
     var playButton = document.getElementById('playButton');
     var deleteForm = document.getElementById('delete-account-form');
@@ -160,11 +136,6 @@ function updateEventListeners() {
     if (gameRequestButtons) {
         gameRequestButtons.forEach(function(button) {
             button.removeEventListener('click', gameResponseHandler);
-        })
-    }
-    if (profileLinks) {
-        profileLinks.forEach(function(link) {
-            link.removeEventListener('click', profileLinkHandler);
         })
     }
     if (gameRenderButton)
@@ -225,11 +196,6 @@ function updateEventListeners() {
     if (gameRequestButtons) {
         gameRequestButtons.forEach(function(button) {
             button.addEventListener('click', gameResponseHandler);
-        })
-    }
-    if (profileLinks) {
-        profileLinks.forEach(function(link) {
-            link.addEventListener('click', profileLinkHandler);
         })
     }
     if (gameRenderButton)
@@ -509,6 +475,8 @@ const profileLinkHandler = async (event) => {
 
     let profileUrl = new URL(event.target.href);
     console.log("profile url " + profileUrl);
+    if (profileUrl == window.location.href)
+		return ;
     let profilePath = profileUrl.pathname;
     console.log("profile path " + profilePath);
     let profileUsername = event.target.textContent;
@@ -687,6 +655,6 @@ const automate_register = async (event) => {
 
 
 
-export { profileLinkHandler, checkLogin, updateContent, updateEventListeners, setActive }
+export { profileLinkHandler, checkLogin, updateContent, updateEventListeners}
 
 // export { updateEventListeners, setActive, checkLogin, updateContent }

--- a/srcs/frontend/srcs/js/router.js
+++ b/srcs/frontend/srcs/js/router.js
@@ -96,10 +96,7 @@ const locationHandler = async () => {
 	location = "/";
 	if (location.startsWith('/app/'))
 	location = location.substring(4);
-	
-	console.log("window path: " + window.location.pathname)
-	// if (location == window.location.pathname)
-	// 	return ;
+
 	console.log('locationHandler(): matching this to routes: ' + location)
 	// Check the routes (the views above) for a match, if no match: 404
 	let route = routes[location] || routes[404];

--- a/srcs/frontend/srcs/js/router.js
+++ b/srcs/frontend/srcs/js/router.js
@@ -13,8 +13,7 @@ document.addEventListener("click", (e) => {
 	// Save the clicked element as target
 	const target = e.target;
 	// Check if the clicked element is a part of the nav anchors
-	console.log("target id in click listener" + target.id)
-	if (!target.matches("nav a") || target.id === "profile-nav") {
+	if (!target.matches("nav a")) {
 		return ;
 	}
 	// Prevent the navigation to a new page
@@ -66,6 +65,8 @@ const route = (event) => {
 	event = event || window.event;
 	event.preventDefault();
 	// Update browser history without triggering page reload
+	console.log("route event target : " + event.target.href)
+	console.log("route window location : " + window.location.href)
 	if (event.target.href == window.location.href)
 		return ;
 	console.log('route(): pushing this to history: ' + event.target.href);
@@ -90,12 +91,15 @@ const locationHandler = async () => {
 	let location = window.location.pathname;
 	// Redirect https://example.com to https://example.com/ in order to land on home page
 	if (location.endsWith('/'))
-		location = location.slice(0, -1);
+	location = location.slice(0, -1);
 	if (location.length == 0)
-		location = "/";
+	location = "/";
 	if (location.startsWith('/app/'))
-		location = location.substring(4);
-
+	location = location.substring(4);
+	
+	console.log("window path: " + window.location.pathname)
+	// if (location == window.location.pathname)
+	// 	return ;
 	console.log('locationHandler(): matching this to routes: ' + location)
 	// Check the routes (the views above) for a match, if no match: 404
 	let route = routes[location] || routes[404];


### PR DESCRIPTION
This PR fixes the active link highlighting and double loading of profile pages.

- nav link highlighting was moved to be checked in the Django templates
- profile pages were being loaded twice after the fix to allow direct navigation to them using the locationHandler script. They were changed to be wrapped in nav elements and the listeners for them were removed from index.js. The handler remains as the Chat is using it still. Need to check if chat is double triggering the navigation as well.