### PR TITLE
Pc 96 character limiting on forms

### DIFF
--- a/srcs/backend/transcendence/srcs/app/forms.py
+++ b/srcs/backend/transcendence/srcs/app/forms.py
@@ -7,9 +7,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 class RegistrationForm(forms.Form):
-    username = forms.CharField(label='Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username', "class": "form-control"}), max_length=256, required=True)
-    first_name = forms.CharField(label='First Name', widget=forms.TextInput(attrs={'placeholder': 'Enter given name', "class": "form-control"}), max_length=256, required=True)
-    last_name = forms.CharField(label='Last Name', widget=forms.TextInput(attrs={'placeholder': 'Enter family name', "class": "form-control"}), max_length=256, required=True)
+    username = forms.CharField(label='Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username', "class": "form-control"}), max_length=50, required=True)
+    first_name = forms.CharField(label='First Name', widget=forms.TextInput(attrs={'placeholder': 'Enter given name', "class": "form-control"}), max_length=50, required=True)
+    last_name = forms.CharField(label='Last Name', widget=forms.TextInput(attrs={'placeholder': 'Enter family name', "class": "form-control"}), max_length=50, required=True)
     email = forms.EmailField(label='Email', widget=forms.TextInput(attrs={'placeholder': 'Enter email', "class": "form-control"}), max_length=320, required=True)
     password = forms.CharField(label="Password", widget=forms.PasswordInput(attrs={'placeholder': 'Enter password', "class": "form-control"}))
     confirm_password = forms.CharField(label="Confirm Password", widget=forms.PasswordInput(attrs={'placeholder': 'Confirm password', "class": "form-control"}))
@@ -57,7 +57,7 @@ class RegistrationForm(forms.Form):
         
 
 class LoginForm(forms.Form):
-    username = forms.CharField(label='Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username', "class": "form-control"}), max_length=256, required=True)
+    username = forms.CharField(label='Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username', "class": "form-control"}), max_length=50, required=True)
     password = forms.CharField(label="Password", widget=forms.PasswordInput(attrs={'placeholder': 'Enter password', "class": "form-control"}))
 
 
@@ -71,7 +71,6 @@ class PlayerAuthForm(forms.Form):
             self.fields['game_id'] = forms.IntegerField(widget=forms.HiddenInput(), initial=kwargs['game_id'])
 
 class DeleteAccountForm(forms.Form):
-    # username = forms.CharField(label='Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username'}), max_length=256, required=True)
     password = forms.CharField(label="Password", widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Enter password'}))
     confirm_password = forms.CharField(label="Confirm Password", widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Confirm password'}))
 
@@ -127,7 +126,7 @@ class UpdateEmailForm(forms.Form):
 
 
 class AddFriendForm(forms.Form):
-    username = forms.CharField(label='Username to friend or block', widget=forms.TextInput(attrs={'placeholder': 'Enter username', 'class':'form-control'}), max_length=256, required=True)
+    username = forms.CharField(label='Username to friend or block', widget=forms.TextInput(attrs={'placeholder': 'Enter username', 'class':'form-control'}), max_length=50, required=True)
 
     def is_valid(self):
         valid = super().is_valid()
@@ -147,8 +146,8 @@ class AddFriendForm(forms.Form):
 
 
 class UpdateNameForm(forms.Form):
-    first_name = forms.CharField(label='First Name', widget=forms.TextInput(attrs={'placeholder': 'Enter given name', 'class': 'form-control'}), max_length=256, required=True)
-    last_name = forms.CharField(label='Last Name', widget=forms.TextInput(attrs={'placeholder': 'Enter family name', 'class': 'form-control'}), max_length=256, required=True)
+    first_name = forms.CharField(label='First Name', widget=forms.TextInput(attrs={'placeholder': 'Enter given name', 'class': 'form-control'}), max_length=50, required=True)
+    last_name = forms.CharField(label='Last Name', widget=forms.TextInput(attrs={'placeholder': 'Enter family name', 'class': 'form-control'}), max_length=50, required=True)
 
 
 class UploadImageForm(forms.ModelForm):
@@ -164,7 +163,7 @@ class GameRequestForm(forms.Form):
     ]
     
     game_type = forms.ChoiceField(widget=forms.RadioSelect(attrs={'class': 'form-check-input'}), choices=GAME_TYPE_CHOICES, label='Choose Game Type:')
-    username = forms.CharField(label='Enter username', widget=forms.TextInput(attrs={'placeholder': 'Enter username', 'class': 'form-control'}), max_length=256, required=True)
+    username = forms.CharField(label='Enter username', widget=forms.TextInput(attrs={'placeholder': 'Enter username', 'class': 'form-control'}), max_length=50, required=True)
 
     def is_valid(self):
         valid = super().is_valid()
@@ -184,8 +183,8 @@ class LocalGameForm(forms.Form):
         (GameInstance.COLOR, 'Color'),
     ]
     game_type = forms.ChoiceField(choices=GAME_TYPE_CHOICES, label='Game Type')
-    username = forms.CharField(label='P2 Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username'}), max_length=256, required=True)
-    password = forms.CharField(label='P2 Password', widget=forms.PasswordInput(attrs={'placeholder': 'Enter password'}), max_length=256, required=True)
+    username = forms.CharField(label='P2 Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username'}), max_length=50, required=True)
+    password = forms.CharField(label='P2 Password', widget=forms.PasswordInput(attrs={'placeholder': 'Enter password'}), required=True) #max_length=50
     
     def is_valid(self):
         valid = super().is_valid()
@@ -210,7 +209,7 @@ class StartTournamentForm(forms.Form):
         (GameInstance.COLOR, 'Color'),
     ]
     game_type = forms.ChoiceField(widget=forms.RadioSelect(attrs={'class': 'form-check-input'}), choices=GAME_TYPE_CHOICES, label='Choose Game Type:')
-    alias = forms.CharField(label='Enter alias', widget=forms.TextInput(attrs={'placeholder': 'Enter alias', 'class': 'form-control'}), max_length=256, required=True)
+    alias = forms.CharField(label='Enter alias', widget=forms.TextInput(attrs={'placeholder': 'Enter alias', 'class': 'form-control'}), max_length=50, required=True)
     
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -219,7 +218,7 @@ class StartTournamentForm(forms.Form):
 
 
 class TournamentInviteForm(forms.Form):
-    username = forms.CharField(label='Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username', 'class': 'form-control'}), max_length=256, required=True)
+    username = forms.CharField(label='Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username', 'class': 'form-control'}), max_length=50, required=True)
 
     def is_valid(self):
         valid = super().is_valid()
@@ -238,4 +237,4 @@ class TournamentInviteForm(forms.Form):
             self.fields['formname'] = forms.CharField(widget=forms.HiddenInput(), initial=kwargs['formname'])
 
 class TournamentJoinForm(forms.Form):
-    alias = forms.CharField(label='Alias', widget=forms.TextInput(attrs={'placeholder': 'Enter alias', 'class': 'form-control'}), max_length=256, required=True)
+    alias = forms.CharField(label='Alias', widget=forms.TextInput(attrs={'placeholder': 'Enter alias', 'class': 'form-control'}), max_length=50, required=True)

--- a/srcs/backend/transcendence/srcs/app/forms.py
+++ b/srcs/backend/transcendence/srcs/app/forms.py
@@ -11,8 +11,8 @@ class RegistrationForm(forms.Form):
     first_name = forms.CharField(label='First Name', widget=forms.TextInput(attrs={'placeholder': 'Enter given name', "class": "form-control"}), max_length=50, required=True)
     last_name = forms.CharField(label='Last Name', widget=forms.TextInput(attrs={'placeholder': 'Enter family name', "class": "form-control"}), max_length=50, required=True)
     email = forms.EmailField(label='Email', widget=forms.TextInput(attrs={'placeholder': 'Enter email', "class": "form-control"}), max_length=320, required=True)
-    password = forms.CharField(label="Password", widget=forms.PasswordInput(attrs={'placeholder': 'Enter password', "class": "form-control"}))
-    confirm_password = forms.CharField(label="Confirm Password", widget=forms.PasswordInput(attrs={'placeholder': 'Confirm password', "class": "form-control"}))
+    password = forms.CharField(label="Password", widget=forms.PasswordInput(attrs={'placeholder': 'Enter password', "class": "form-control"}), max_length=64, required=True)
+    confirm_password = forms.CharField(label="Confirm Password", widget=forms.PasswordInput(attrs={'placeholder': 'Confirm password', "class": "form-control"}), max_length=64, required=True)
 
     def is_valid(self):
         valid = super().is_valid()
@@ -58,11 +58,11 @@ class RegistrationForm(forms.Form):
 
 class LoginForm(forms.Form):
     username = forms.CharField(label='Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username', "class": "form-control"}), max_length=50, required=True)
-    password = forms.CharField(label="Password", widget=forms.PasswordInput(attrs={'placeholder': 'Enter password', "class": "form-control"}))
+    password = forms.CharField(label="Password", widget=forms.PasswordInput(attrs={'placeholder': 'Enter password', "class": "form-control"}), max_length=64, required=True)
 
 
 class PlayerAuthForm(forms.Form):
-    password = forms.CharField(label='Password', widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Enter password'}))
+    password = forms.CharField(label='Password', widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Enter password'}), max_length=64, required=True)
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if 'username' in kwargs:
@@ -71,8 +71,8 @@ class PlayerAuthForm(forms.Form):
             self.fields['game_id'] = forms.IntegerField(widget=forms.HiddenInput(), initial=kwargs['game_id'])
 
 class DeleteAccountForm(forms.Form):
-    password = forms.CharField(label="Password", widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Enter password'}))
-    confirm_password = forms.CharField(label="Confirm Password", widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Confirm password'}))
+    password = forms.CharField(label="Password", widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Enter password'}), max_length=64, required=True)
+    confirm_password = forms.CharField(label="Confirm Password", widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Confirm password'}), max_length=64, required=True)
 
     def is_valid(self):
         valid = super().is_valid()
@@ -87,8 +87,8 @@ class DeleteAccountForm(forms.Form):
 
 
 class UpdatePasswordForm(forms.Form):
-    new_password = forms.CharField(label="New Password", widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Enter new password'}))
-    new_confirm_password = forms.CharField(label="Confirm New Password", widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Confirm new password'}))
+    new_password = forms.CharField(label="New Password", widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Enter new password'}), max_length=64, required=True)
+    new_confirm_password = forms.CharField(label="Confirm New Password", widget=forms.PasswordInput(attrs={'class': 'form-control','placeholder': 'Confirm new password'}), max_length=64, required=True)
     
     def is_valid(self):
         valid = super().is_valid()
@@ -184,7 +184,7 @@ class LocalGameForm(forms.Form):
     ]
     game_type = forms.ChoiceField(choices=GAME_TYPE_CHOICES, label='Game Type')
     username = forms.CharField(label='P2 Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username'}), max_length=50, required=True)
-    password = forms.CharField(label='P2 Password', widget=forms.PasswordInput(attrs={'placeholder': 'Enter password'}), required=True) #max_length=50
+    password = forms.CharField(label='P2 Password', widget=forms.PasswordInput(attrs={'placeholder': 'Enter password'}), required=True, max_length=64, required=True) #max_length=50
     
     def is_valid(self):
         valid = super().is_valid()

--- a/srcs/backend/transcendence/srcs/app/forms.py
+++ b/srcs/backend/transcendence/srcs/app/forms.py
@@ -184,7 +184,7 @@ class LocalGameForm(forms.Form):
     ]
     game_type = forms.ChoiceField(choices=GAME_TYPE_CHOICES, label='Game Type')
     username = forms.CharField(label='P2 Username', widget=forms.TextInput(attrs={'placeholder': 'Enter username'}), max_length=50, required=True)
-    password = forms.CharField(label='P2 Password', widget=forms.PasswordInput(attrs={'placeholder': 'Enter password'}), required=True, max_length=64, required=True) #max_length=50
+    password = forms.CharField(label='P2 Password', widget=forms.PasswordInput(attrs={'placeholder': 'Enter password'}), max_length=64, required=True) #max_length=50
     
     def is_valid(self):
         valid = super().is_valid()

--- a/srcs/backend/transcendence/srcs/app/models.py
+++ b/srcs/backend/transcendence/srcs/app/models.py
@@ -41,9 +41,9 @@ class CustomUserManager(BaseUserManager):
 
 # Create your models here.
 class CustomUser(AbstractBaseUser):
-    username = models.CharField(max_length = 254, unique=True)
-    first_name = models.CharField(max_length = 254, null=True)
-    last_name = models.CharField(max_length = 254, null=True)
+    username = models.CharField(max_length = 50, unique=True)
+    first_name = models.CharField(max_length = 50, null=True)
+    last_name = models.CharField(max_length = 50, null=True)
     email = models.EmailField(max_length = 320, blank=True, null=True)
     is_online = models.BooleanField(default=False)
     last_seen = models.DateTimeField(auto_now=True)
@@ -157,7 +157,7 @@ class Participant(models.Model):
     ]
     user = models.ForeignKey("CustomUser", on_delete=models.CASCADE)
     tournament = models.ForeignKey("Tournament", on_delete=models.CASCADE)
-    alias = models.CharField(max_length=255, default="alias")
+    alias = models.CharField(max_length=50, default="alias")
     status = models.CharField(max_length=10, choices=STATUS_CHOICES, default=PENDING)
 
     class Meta:

--- a/srcs/backend/transcendence/srcs/app/models.py
+++ b/srcs/backend/transcendence/srcs/app/models.py
@@ -193,14 +193,3 @@ class Tournament(models.Model):
         highest_level = self.match_set.aggregate(max_level=models.Max('level'))['max_level']
         logger.debug('Highest match level in tournament: ' + str(highest_level))
         return highest_level if highest_level is not None else 0
-
-
-# user profile model
-#  language -> maybe add to CustomUser model?
-#  picture
-#  custom setting for paddle?
-
-# stats model -  individual game stats that linked to the user
-#  define what about a game to save
-#  expect game service to send game info to us
-


### PR DESCRIPTION
Changed max_length for form fields and checked they matched the corresponding models.

- email fields accept up to 320 characters for all elements (from RTF recs)
- password fields limited to 64 characters (based on OWASP min length allowed recs)
- all other fields limited to 50 characters