### PR TITLE
Pc 98 dashboard error handling

### DIFF
--- a/srcs/backend/transcendence/srcs/app/user/dashboard.py
+++ b/srcs/backend/transcendence/srcs/app/user/dashboard.py
@@ -16,6 +16,11 @@ def get_stats_for_cli(user:CustomUser, pong_games:QuerySet) -> dict:
     pong_stats["wins"] = len(won_games)
     return pong_stats
 
+def check_user_not_none(user):
+    if user is None:
+        return "Deleted User"
+    else:
+        return user.username
 
 def get_pong_history(username:str, pong_games:QuerySet) -> dict:
     pong_history = {}
@@ -25,15 +30,18 @@ def get_pong_history(username:str, pong_games:QuerySet) -> dict:
         entry = {}
         entry["game"] = game.game
         entry["date"] = game.updated_at
-        if game.p1.username == username:
-            entry["opponent"] = game.p2
+        p1_username = check_user_not_none(game.p1)
+        p2_username = check_user_not_none(game.p2)
+
+        if p1_username == username:
+            entry["opponent"] = p2_username
             entry["opponent_score"] = game.p2_score
             entry["user_score"] = game.p1_score
         else:
-            entry["opponent"] = game.p1
+            entry["opponent"] = p1_username
             entry["opponent_score"] = game.p1_score
             entry["user_score"] = game.p2_score
-        entry["winner"] = game.winner.username
+        entry["winner"] = check_user_not_none(game.winner)
         pong_history[iter] = entry
     logger.debug(pong_history)
     return pong_history
@@ -93,11 +101,14 @@ def get_color_history(username:str, color_games:QuerySet) -> dict:
         entry = {}
         entry["game"] = game.game
         entry["date"] = game.updated_at
-        if game.p1.username == username:
-            entry["opponent"] = game.p2
+        p1_username = check_user_not_none(game.p1)
+        p2_username = check_user_not_none(game.p2)
+
+        if p1_username == username:
+            entry["opponent"] = p2_username
         else:
-            entry["opponent"] = game.p1
-        entry["winner"] = game.winner.username
+            entry["opponent"] = p1_username
+        entry["winner"] = check_user_not_none(game.winner)
         entry["turns_to_win"] = game.turns_to_win
         color_history[iter] = entry
     logger.debug(color_history)

--- a/srcs/backend/transcendence/srcs/app/user/dashboard.py
+++ b/srcs/backend/transcendence/srcs/app/user/dashboard.py
@@ -42,6 +42,7 @@ def get_pong_history(username:str, pong_games:QuerySet) -> dict:
             entry["opponent_score"] = game.p1_score
             entry["user_score"] = game.p2_score
         entry["winner"] = check_user_not_none(game.winner)
+        entry["is_tournament_game"] = game.tournament_match
         pong_history[iter] = entry
     logger.debug(pong_history)
     return pong_history
@@ -89,6 +90,7 @@ def get_pong_stats(user:CustomUser, pong_games:QuerySet) -> dict:
     pong_stats['largest_loss_margin'] = largest_loss_margin
     pong_stats['longest_rally'] = longest_rally
     pong_stats['win_percent'] = round((wins / pong_stats["games_played"]) * 100, 2)
+    pong_stats["tournament_games"] = len(pong_games.filter(tournament_match=True))
     logger.debug(pong_stats)
     return pong_stats
 
@@ -110,6 +112,7 @@ def get_color_history(username:str, color_games:QuerySet) -> dict:
             entry["opponent"] = p1_username
         entry["winner"] = check_user_not_none(game.winner)
         entry["turns_to_win"] = game.turns_to_win
+        entry["is_tournament_game"] = game.tournament_match
         color_history[iter] = entry
     logger.debug(color_history)
     return color_history
@@ -142,6 +145,7 @@ def get_color_stats(user:CustomUser, color_games:QuerySet) -> dict:
         color_stats["average_move_to_win"] = sum_moves_to_win / wins
     else:
         color_stats["average_move_to_win"] = 0
+    color_stats["tournament_games"] = len(color_games.filter(tournament_match=True))
     logger.debug(color_stats)
     return color_stats
 

--- a/srcs/backend/transcendence/srcs/templates/user/profile_partials/game_history.html
+++ b/srcs/backend/transcendence/srcs/templates/user/profile_partials/game_history.html
@@ -8,6 +8,7 @@
 			<th scope="col">Foe Score</th>
 			<th scope="col">User Score</th>
 			<th scope="col">Winner</th>
+			<th scope="col">Tournamnet Game</th>
 		</thead>
 		<tbody>
 		{% for key, entry in history.pong.items %}
@@ -18,6 +19,13 @@
 				<td>{{ entry.opponent_score }}</td>
 				<td>{{ entry.user_score }}</td>
 				<td>{{ entry.winner }}</td>
+				<td>
+					{% if entry.is_tournament_game %}
+					Y
+					{% else %}
+					N
+					{% endif %}
+				</td>
 			</tr>
 		{% empty %}
 			<tr>
@@ -34,6 +42,7 @@
 			<th scope="col">Foe</th>
 			<th scope="col">Moves to Win</th>
 			<th scope="col">Winner</th>
+			<th scope="col">Tournamnet Game</th>
 		</thead>
 		<tbody>
 		{% for key, entry in history.color.items %}
@@ -44,6 +53,13 @@
 				<td>{{ entry.opponent_score }}</td>
 				<td>{{ entry.user_score }}</td>
 				<td>{{ entry.winner }}</td>
+				<td>
+					{% if entry.is_tournament_game %}
+					Y
+					{% else %}
+					N
+					{% endif %}
+				</td>
 			</tr>
 		{% empty %}
 			<tr>

--- a/srcs/backend/transcendence/srcs/templates/user/profile_partials/stats.html
+++ b/srcs/backend/transcendence/srcs/templates/user/profile_partials/stats.html
@@ -7,9 +7,10 @@
 				<p>Total games: {{ stats.pong.games_played }}</p>
 				<p>Total wins: {{ stats.pong.wins }}</p>
 				<p>Win rate: {{ stats.pong.win_percent }}%</p>
-				<p>Largest win margin: {{ stats.pong.largest_win_margin }}</p>
-				<p>Largest loss margin: {{ stats.pong.largest_loss_margin }}</p>
+				<p>Best win margin: {{ stats.pong.largest_win_margin }}</p>
+				<p>Worst loss margin: {{ stats.pong.largest_loss_margin }}</p>
 				<p>Longest rally: {{ stats.pong.longest_rally }}</p>
+				<p>Tournament Games Played: {{ stats.pong.tournament_games }}</p>
 			{% else %}
 				<p>No Pong statistics to report</p>
 			{% endif %}
@@ -22,6 +23,7 @@
 				<p>Win rate: {{ stats.color.win_percent }}%</p>
 				<p>Least moves to win: {{ stats.color.least_moves_to_win }}</p>
 				<p>Average moves to win: {{ stats.color.average_move_to_win }}</p>
+				<p>Tournament Games Played: {{ stats.color.tournament_games }}</p>
 			{% else %}
 				<p>No ColorWar statistics to report</p>
 			{% endif %}


### PR DESCRIPTION
This PR fixes internal server error for reporting game histories with deleted users. Additionally, added tournament game counts and status to the history and stats. 