### PR TITLE
Pc 88 chat notifications blocking invites

### DIFF
--- a/srcs/backend/transcendence/conf/requirements.txt
+++ b/srcs/backend/transcendence/conf/requirements.txt
@@ -1,5 +1,5 @@
 Django==4.2.9
-channels==4.0.0
+channels==4.1.0
 daphne==4.0.0
 Twisted[tls,http2]
 psycopg2-binary==2.9.9

--- a/srcs/backend/transcendence/srcs/app/consumers.py
+++ b/srcs/backend/transcendence/srcs/app/consumers.py
@@ -92,6 +92,8 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
                 case _:
                     print("Invalid event by user: ", self.scope["user"].username)
 
+        except KeyError as e:
+                await self.error_response("Content invalid.")
         except Exception as e:
             if hasattr(e, "message"):
                 await self.error_response(e.message)

--- a/srcs/backend/transcendence/srcs/app/consumers.py
+++ b/srcs/backend/transcendence/srcs/app/consumers.py
@@ -25,21 +25,31 @@ def chat_system_message(user, message: str):
 class UserConsumer(AsyncJsonWebsocketConsumer):
 
     async def connect(self):
-        await self.accept()
-        user : CustomUser = self.scope["user"]
+        try:
+            await self.accept()
+            user : CustomUser = self.scope["user"]
 
-        if not user.is_authenticated or user.is_anonymous:
-            return await self.close()
+            if not user.is_authenticated or user.is_anonymous:
+                return await self.close()
 
-        for group in [user.username, "Global"]:
-            await self.channel_layer.group_add(group, self.channel_name)
+            for group in [user.username, "Global"]:
+                await self.channel_layer.group_add(group, self.channel_name)
+        except Exception as e:
+            logger.error(user.username if user.username else "UNKNOWN USER " + " connection ERROR: " + str(e))
+            await self.close();
 
 
     async def disconnect(self, close_code):
-        user : CustomUser = self.scope["user"]
+        try:
+            user : CustomUser = self.scope["user"]
 
-        for group in [user.username, "Global"]:
-            await self.channel_layer.group_discard(group, self.channel_name)
+            if not user.is_authenticated or user.is_anonymous:
+                return
+
+            for group in [user.username, "Global"]:
+                await self.channel_layer.group_discard(group, self.channel_name)
+        except Exception as e:
+            logger.error(user.username if user.username else "UNKNOWN USER " + " disconnection ERROR: " + str(e))
     
 
     async def receive_json(self, content):

--- a/srcs/backend/transcendence/srcs/app/consumers.py
+++ b/srcs/backend/transcendence/srcs/app/consumers.py
@@ -87,7 +87,7 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
                 case "chat.invite":
                     user_to_invite: CustomUser = await CustomUser.objects.aget(username=content["username"])
                     await sync_to_async(app.play.as_user_challenge_user)(user, user_to_invite, content["game"])
-                    await self.chat_system(user_to_invite.username + " has challenged")
+                    await self.chat_system(user_to_invite.username + " has been challenged")
 
                 case _:
                     print("Invalid event by user: ", self.scope["user"].username)

--- a/srcs/backend/transcendence/srcs/app/consumers.py
+++ b/srcs/backend/transcendence/srcs/app/consumers.py
@@ -1,12 +1,12 @@
 import logging
-import json
 
-from asgiref.sync import async_to_sync
+from asgiref.sync import sync_to_async, async_to_sync
 
-from channels.generic.websocket import AsyncWebsocketConsumer
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from channels.layers import get_channel_layer
 
 from app.models import CustomUser
+from app.user.relations import as_user_block_user
 
 logger = logging.getLogger(__name__)
 
@@ -19,14 +19,7 @@ def chat_system_message(user, message: str):
             "message" : message,
         })
 
-def _has_keys(event: dict, keys):
-    for key in keys:
-        if not key in event:
-            return False
-    return True
-
-
-class UserConsumer(AsyncWebsocketConsumer):
+class UserConsumer(AsyncJsonWebsocketConsumer):
 
     async def connect(self):
         await self.accept()
@@ -44,73 +37,93 @@ class UserConsumer(AsyncWebsocketConsumer):
             await self.channel_layer.group_discard(group, self.channel_name)
     
 
-    async def receive(self, text_data):
+    async def receive_json(self, content):
         user : CustomUser = self.scope["user"]
+
         if not user.is_authenticated or user.is_anonymous:
             return await self.close()
 
         try:
-            event: dict = json.loads(text_data)
-        except:
-            print("Invalid JSON sent by user: ", self.scope["user"].username)
-            return
+            match content["type"]:
+                case "chat.broadcast":
+                    if "message" not in content:
+                        print("Chat broadcast event with missing fields by user: ", self.scope["user"].username)
+                        return
+                    content["sender"] = user.username
+                    await self.channel_layer.group_send(self.groups[1], content)
 
-        match event["type"]:
-            case "chat.broadcast":
-        
-                if not _has_keys(event, ["message"]):
-                    print("Chat broadcast event with missing fields by user: ", self.scope["user"].username)
-                    return
+                case "chat.whisper":
+                    if "receiver" not in content or "message" not in content:
+                        print("Chat message event with missing fields by user: ", self.scope["user"].username)
+                        return
 
-                event["sender"] = self.scope["user"].username
+                    if not content["receiver"] in self.channel_layer.groups:
+                        await self.error_response("No such user")
+                        return
 
-                await self.channel_layer.group_send(self.groups[1], event)
+                    content["sender"] = user.username
+                    await self.channel_layer.group_send(content["receiver"], content)
+                    if (content["receiver"] != self.groups[0]):
+                        await self.channel_layer.group_send(self.groups[0], content)
 
-            case "chat.whisper":
-                if not _has_keys(event, ["receiver", "message"]):
-                    print("Chat message event with missing fields by user: ", self.scope["user"].username)
-                    return
+                case "chat.block":
+                    name_to_block = content["username"]
 
-                if not event["receiver"] in self.channel_layer.groups:
-                    await self.error_response("No such user")
-                    return
+                    blocked: CustomUser = await CustomUser.objects.aget(username=name_to_block)
+                    await sync_to_async(as_user_block_user)(self.scope["user"], blocked)
+                    await self.chat_system(name_to_block + " has been blocked")
 
-                event["sender"] = self.scope["user"].username
+                case "chat.unblock":
+                    name_to_unblock: str = content["username"]
+                    user_to_unblock = await CustomUser.objects.aget(username=name_to_unblock)
+                    client: CustomUser = self.scope["user"]
+                    await client.blocked_users.aremove(user_to_unblock);
+                    await client.asave()
 
-                await self.channel_layer.group_send(event["receiver"], event)
-                if (event["receiver"] != self.groups[0]):
-                    await self.channel_layer.group_send(self.groups[0], event)
+                    await self.chat_system(name_to_unblock + " has been unblocked")
 
-            case _:
-                print("Invalid event by user: ", self.scope["user"].username)
+                case "chat.invite":
+                    user_to_unblock: CustomUser = await CustomUser.objects.aget(username=name_to_unblock)
+
+                case _:
+                    print("Invalid event by user: ", self.scope["user"].username)
+
+        except Exception as e:
+            if hasattr(e, "message"):
+                await self.error_response(e.message)
+            else:
+                await self.error_response(str(e))
 
 
-    async def chat_broadcast(self, event : dict):
+    async def chat_broadcast(self, content : dict):
         receiver : CustomUser = self.scope["user"]
-        sender_name : str = event["sender"]
+        sender_name : str = content["sender"]
 
         if await receiver.blocked_users.filter(username=sender_name).aexists():
             return
 
-        await self.send(text_data = json.dumps(event))
+        await self.send_json(content)
 
 
-    async def chat_whisper(self, event : dict):
+    async def chat_whisper(self, content : dict):
         receiver : CustomUser = self.scope["user"]
-        sender_name : str = event["sender"]
+        sender_name : str = content["sender"]
 
         if await receiver.blocked_users.filter(username=sender_name).aexists():
             return
 
-        del event["receiver"]
+        del content["receiver"]
 
-        await self.send(text_data = json.dumps(event))
+        await self.send_json(content)
 
-    async def chat_system(self, event : dict):
-        await self.send(text_data = json.dumps(event))
+    async def chat_system(self, content : str):
+        await self.send_json({
+            "type" : "chat.system",
+            "message" : content
+        })
 
-    async def error_response(self, message : str):
-        await self.send(text_data = json.dumps({
+    async def error_response(self, content : str):
+        await self.send_json({
             "type" : "chat.error",
-            "message" : message,
-        }));
+            "message" : content,
+        });

--- a/srcs/backend/transcendence/srcs/app/consumers.py
+++ b/srcs/backend/transcendence/srcs/app/consumers.py
@@ -32,6 +32,7 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
 
         for group in [user.username, "Global"]:
             await self.channel_layer.group_add(group, self.channel_name)
+        print("Connected " + user.username)
 
 
     async def disconnect(self, close_code):
@@ -39,6 +40,7 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
 
         for group in [user.username, "Global"]:
             await self.channel_layer.group_discard(group, self.channel_name)
+        print("Disconnected " + user.username)
     
 
     async def receive_json(self, content):

--- a/srcs/backend/transcendence/srcs/app/consumers.py
+++ b/srcs/backend/transcendence/srcs/app/consumers.py
@@ -90,7 +90,7 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
 
                 case "chat.invite":
                     user_to_invite: CustomUser = await CustomUser.objects.aget(username=content["username"])
-                    await sync_to_async(app.play.as_user_challenge_user)(user, user_to_invite, content["game"].lower())
+                    await sync_to_async(app.play.as_user_challenge_user)(user, user_to_invite, content["game"])
                     await self.chat_system(user_to_invite.username + " has been challenged.")
 
                 case _:

--- a/srcs/backend/transcendence/srcs/app/consumers.py
+++ b/srcs/backend/transcendence/srcs/app/consumers.py
@@ -1,4 +1,5 @@
 import logging
+import builtins
 
 from asgiref.sync import sync_to_async, async_to_sync
 
@@ -61,7 +62,7 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
                 case "chat.whisper":
                     receiver = content["receiver"]
                     if not receiver in self.channel_layer.groups:
-                        await self.error_response("User not reachable")
+                        await self.error_response("User not reachable.")
                         return
                     content = {
                         "type" : content["type"],
@@ -76,18 +77,21 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
                     name_to_block = content["username"]
                     blocked: CustomUser = await CustomUser.objects.aget(username=name_to_block)
                     await sync_to_async(as_user_block_user)(self.scope["user"], blocked)
-                    await self.chat_system(name_to_block + " has been blocked")
+                    await self.chat_system(name_to_block + " has been blocked.")
 
                 case "chat.unblock":
                     user_to_unblock: CustomUser = await CustomUser.objects.aget(username=content["username"])
-                    await user.blocked_users.aremove(user_to_unblock);
-                    await user.asave()
-                    await self.chat_system(user_to_unblock.username + " has been unblocked")
+                    if (await user.blocked_users.filter(username=user_to_unblock).aexists()):
+                        await user.blocked_users.aremove(user_to_unblock);
+                        await user.asave()
+                        await self.chat_system(user_to_unblock.username + " has been unblocked.")
+                    else:
+                        await self.chat_system(user_to_unblock.username + " isn't blocked!")
 
                 case "chat.invite":
                     user_to_invite: CustomUser = await CustomUser.objects.aget(username=content["username"])
                     await sync_to_async(app.play.as_user_challenge_user)(user, user_to_invite, content["game"].lower())
-                    await self.chat_system(user_to_invite.username + " has been challenged")
+                    await self.chat_system(user_to_invite.username + " has been challenged.")
 
                 case _:
                     print("Invalid event by user: ", self.scope["user"].username)
@@ -112,19 +116,21 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
 
 
     async def chat_whisper(self, content : dict):
-        receiver : CustomUser = self.scope["user"]
-        sender_name : str = content["sender"]
-
-        if await receiver.blocked_users.filter(username=sender_name).aexists():
-            return
-
         await self.send_json(content)
 
-    async def chat_system(self, content : str):
-        await self.send_json({
-            "type" : "chat.system",
-            "message" : content
-        })
+
+    async def chat_system(self, content):
+        match (content):
+            case str(content):
+                await self.send_json({
+                    "type" : "chat.system",
+                    "message" : content,
+                })
+            case dict(content):
+                await self.send_json(content)
+            case _: 
+                print("Unknown dispatch type for chat.system")
+
 
     async def error_response(self, content : str):
         await self.send_json({

--- a/srcs/backend/transcendence/srcs/app/consumers.py
+++ b/srcs/backend/transcendence/srcs/app/consumers.py
@@ -32,7 +32,6 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
 
         for group in [user.username, "Global"]:
             await self.channel_layer.group_add(group, self.channel_name)
-        print("Connected " + user.username)
 
 
     async def disconnect(self, close_code):
@@ -40,7 +39,6 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
 
         for group in [user.username, "Global"]:
             await self.channel_layer.group_discard(group, self.channel_name)
-        print("Disconnected " + user.username)
     
 
     async def receive_json(self, content):
@@ -88,7 +86,7 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
 
                 case "chat.invite":
                     user_to_invite: CustomUser = await CustomUser.objects.aget(username=content["username"])
-                    await sync_to_async(app.play.as_user_challenge_user)(user, user_to_invite, content["game"])
+                    await sync_to_async(app.play.as_user_challenge_user)(user, user_to_invite, content["game"].lower())
                     await self.chat_system(user_to_invite.username + " has been challenged")
 
                 case _:

--- a/srcs/backend/transcendence/srcs/app/consumers.py
+++ b/srcs/backend/transcendence/srcs/app/consumers.py
@@ -56,7 +56,7 @@ class UserConsumer(AsyncJsonWebsocketConsumer):
                         "sender" : user.username,
                         "message" : content["message"]
                     }
-                    await self.channel_layer.group_send(user.username, sanitized_content)
+                    await self.channel_layer.group_send("Global", sanitized_content)
 
                 case "chat.whisper":
                     receiver = content["receiver"]

--- a/srcs/backend/transcendence/srcs/app/play.py
+++ b/srcs/backend/transcendence/srcs/app/play.py
@@ -200,7 +200,7 @@ def as_user_challenge_user(user: CustomUser, challengee: CustomUser, game_name: 
         raise ValidationError("You have already sent a game request to this user")
 
     new_game_instance = None
-    match (game_name):
+    match (game_name.lower()):
         case "pong":
             new_game_instance = PongGameInstance(p1=user, p2=challengee, game=game_name, status='Pending')
         case "color":
@@ -373,7 +373,7 @@ def update_tournament(game_instance):
                     logger.debug(f'Scheduled a game: {p1_user.username} vs {p2_user.username}!')
                     # CHAT MODULE let player know in chat that they have a new game
                     for matchup in [(p1_user, p2_user), (p2_user, p1_user)]:
-                        app.consumers.chat_system_message(matchup.first, "Your next tournament match against {name}!".format(name=matchup.second))
+                        app.consumers.chat_system_message(matchup.first, "Your next tournament match is against {name}!".format(name=matchup.second))
 
         else:
             logger.debug('No more levels in tournament, finishing tournament!')
@@ -383,8 +383,8 @@ def update_tournament(game_instance):
             tournament.save()
             # CHAT MODULE announce tournament winner
             winner_username = match.game_instance.winner.username;
-            for user in tournament.participants:
-                app.consumers.chat_system_message(user, "Congratulations to {name} for winning the tournament!".format(name=winner_username))
+            for p in tournament.participants:
+                app.consumers.chat_system_message(p.user, "Congratulations to {name} for winning the tournament!".format(name=winner_username))
     else:
         logger.debug('There are still matches remaining on this level of the tournament')
         match.status = Match.FINISHED
@@ -572,8 +572,8 @@ def tournament_start(request, data):
         return render(request, 'user/play.html', playContext(request, str(e), None))
 
     # CHAT MODULE announce tournament start
-    for user in participants:
-        app.consumers.chat_system_message(user, "Tournament is starting!")
+    for p in participants:
+        app.consumers.chat_system_message(p.user, "Tournament is starting!")
 
     return render(request, 'user/play.html', playContext(request, None, 'Tournament started!'))
 

--- a/srcs/backend/transcendence/srcs/app/play.py
+++ b/srcs/backend/transcendence/srcs/app/play.py
@@ -175,15 +175,13 @@ def playPOST(request):
         game = sent_form.cleaned_data["game_type"]
         as_user_challenge_user(request.user, challenged_user, game)
 
-    # Realistically should have different dispatch for different exceptions
-    except Exception as e:
-        print(e)
+    # Realistically should have different dispatch for various different exceptions
+    except ValidationError as e:
         error_message = e.message if hasattr(e, "message") else str(e)
         return render(request, 'user/play.html', playContext(request, error_message, None))
 
-
-
     return render(request, 'user/play.html', playContext(request, None, "Game invite sent!")) 
+
 
 def as_user_challenge_user(user: CustomUser, challengee: CustomUser, game_name: str):
     # Check if participants have blocked each other

--- a/srcs/backend/transcendence/srcs/app/play.py
+++ b/srcs/backend/transcendence/srcs/app/play.py
@@ -373,7 +373,7 @@ def update_tournament(game_instance):
                     logger.debug(f'Scheduled a game: {p1_user.username} vs {p2_user.username}!')
                     # CHAT MODULE let player know in chat that they have a new game
                     for matchup in [(p1_user, p2_user), (p2_user, p1_user)]:
-                        app.consumers.chat_system_message(matchup.first, "Your next tournament match is against {name}!".format(name=matchup.second))
+                        app.consumers.chat_system_message(matchup[0], "Your next tournament match is against {name}!".format(name=matchup[1].username))
 
         else:
             logger.debug('No more levels in tournament, finishing tournament!')
@@ -383,7 +383,7 @@ def update_tournament(game_instance):
             tournament.save()
             # CHAT MODULE announce tournament winner
             winner_username = match.game_instance.winner.username;
-            for p in tournament.participants:
+            for p in Participant.objects.filter(tournament=tournament):
                 app.consumers.chat_system_message(p.user, "Congratulations to {name} for winning the tournament!".format(name=winner_username))
     else:
         logger.debug('There are still matches remaining on this level of the tournament')

--- a/srcs/backend/transcendence/srcs/app/play.py
+++ b/srcs/backend/transcendence/srcs/app/play.py
@@ -201,9 +201,9 @@ def as_user_challenge_user(user: CustomUser, challengee: CustomUser, game_name: 
 
     new_game_instance = None
     match (game_name):
-        case "Pong":
+        case "pong":
             new_game_instance = PongGameInstance(p1=user, p2=challengee, game=game_name, status='Pending')
-        case "Color":
+        case "color":
             new_game_instance = ColorGameInstance(p1=user, p2=challengee, game=game_name, status='Pending')
         case _:
             raise ValidationError("Invalid game type")

--- a/srcs/backend/transcendence/srcs/app/user/relations.py
+++ b/srcs/backend/transcendence/srcs/app/user/relations.py
@@ -143,12 +143,12 @@ def block_user(request):
 
         as_user_block_user(request.user, blocked_user)
 
-        return render(request, 'user/profile_partials/friends.html', {"friends": friendsContext(request.user.username, None, "Blocked " + blocked_username + "!"), "self_profile": True})
-
-    # Realistically should have different dispatch for different exceptions!
+    # Realistically should have different dispatch for different exceptions.
     except Exception as e:
         error_message = e.message if hasattr(e, "message") else str(e)
         return render(request, 'user/profile_partials/friends.html', {"friends": friendsContext(request.user.username, error_message, None), "self_profile": True})
+
+    return render(request, 'user/profile_partials/friends.html', {"friends": friendsContext(request.user.username, None, "Blocked " + blocked_username + "!"), "self_profile": True})
 
 
 def as_user_block_user(user: CustomUser, blocked: CustomUser):

--- a/srcs/backend/transcendence/srcs/app/user/relations.py
+++ b/srcs/backend/transcendence/srcs/app/user/relations.py
@@ -144,7 +144,7 @@ def block_user(request):
         as_user_block_user(request.user, blocked_user)
 
     # Realistically should have different dispatch for different exceptions.
-    except Exception as e:
+    except ValidationError as e:
         error_message = e.message if hasattr(e, "message") else str(e)
         return render(request, 'user/profile_partials/friends.html', {"friends": friendsContext(request.user.username, error_message, None), "self_profile": True})
 

--- a/srcs/backend/transcendence/srcs/app/user/relations.py
+++ b/srcs/backend/transcendence/srcs/app/user/relations.py
@@ -143,12 +143,9 @@ def block_user(request):
 
         as_user_block_user(request.user, blocked_user)
 
-        ctx = friendsContext(request.user.username, None, "Blocked " + blocked_username + "!")
-        print(ctx)
-        return render(request, 'user/profile_partials/friends.html', {"friends": ctx, "self_profile": True})
-        #return render(request, 'user/profile_partials/friends.html', {"friends": friendsContext(request.user.username, None, "Blocked " + blocked_username + "!"), "self_profile": True})
+        return render(request, 'user/profile_partials/friends.html', {"friends": friendsContext(request.user.username, None, "Blocked " + blocked_username + "!"), "self_profile": True})
 
-    # Realistically should have different dispatch for different exceptions...
+    # Realistically should have different dispatch for different exceptions!
     except Exception as e:
         error_message = e.message if hasattr(e, "message") else str(e)
         return render(request, 'user/profile_partials/friends.html', {"friends": friendsContext(request.user.username, error_message, None), "self_profile": True})

--- a/srcs/backend/transcendence/srcs/templates/user/profile_partials/friends.html
+++ b/srcs/backend/transcendence/srcs/templates/user/profile_partials/friends.html
@@ -3,7 +3,7 @@
 	<div class="alert alert-danger" role="alert">Error: {{friends.error}}</div>
 	{% endif %}
 
-	{% if success %}
+	{% if friends.success %}
 	<div class="alert alert-success" role="alert">{{friends.success}}</div>
 	{% endif %}
 

--- a/srcs/frontend/srcs/js/chat.js
+++ b/srcs/frontend/srcs/js/chat.js
@@ -9,11 +9,11 @@ const submitButton = document.getElementById("chat-submit");
 const logMessageCountMax = 32;
 
 const helpMessage = "\n" +
-                    "/h - Display chat commands.\n" +
-                    "/w [username] message - Send a direct message.\n" +
-                    "/b [username] - Block user.\n" +
-                    "/u [username] - Unblock user.\n" +
-                    "/i [username] [Pong/Color] - Send a game invite.\n";
+                    "/h\t\t\t\t\t\t\t - Display chat commands.\n" +
+                    "/w\t[username] message\t\t - Send a direct message.\n" +
+                    "/b\t[username] \t\t\t\t - Block user.\n" +
+                    "/u\t[username] \t\t\t\t - Unblock user.\n" +
+                    "/i\t[username] [Pong/Color]\t - Send a game invite.\n";
 
 inputField.onkeydown = (e) => { if (e.key === "Enter") { _submitHandler(); e.preventDefault(); } }
 
@@ -48,6 +48,7 @@ function connect() {
     }
 
     _set_disabled(false);
+    _appendMessage( _createSourceElement("System"), helpMessage);
 }
 
 function disconnect() {

--- a/srcs/frontend/srcs/js/chat.js
+++ b/srcs/frontend/srcs/js/chat.js
@@ -10,10 +10,10 @@ const logMessageCountMax = 32;
 
 const helpMessage = "\n" +
                     "/h - Display chat commands.\n" +
-                    "/w - Send a direct message.\n" +
-                    "/b - Block user.\n" +
-                    "/u - Unblock user.\n" +
-                    "/i - Send a game invite.\n";
+                    "/w [username] message - Send a direct message.\n" +
+                    "/b [username] - Block user.\n" +
+                    "/u [username] - Unblock user.\n" +
+                    "/i [username] [Pong/ColorWar] - Send a game invite.\n";
 
 inputField.onkeydown = (e) => { if (e.key === "Enter") { _submitHandler(); e.preventDefault(); } }
 
@@ -96,32 +96,42 @@ function _parseInput(input) {
                     message: args[1]
                 };
             }
-            _appendMessage( _createSourceElement("Error"), "Invalid whisper arguments")
             break;
         }
 
          case "b": {
-            const args = rest.split(/^(\S+)\s+/g).filter(s => { return s != ""; });
-            if (args && args.length == 2) {
-                // BLOCK behaviour
+            const args = rest.trim();
+            if (args && /^[A-Za-z0-9]+$/.test(args)) {
+                return {
+                    type: "chat.block",
+                    username: args,
+                }
             }
+            break;
          }
 
          case "u": {
-            const args = rest.split(/^(\S+)\s+/g).filter(s => { return s != ""; });
-            if (args && args.length == 2) {
-                // UNBLOCK behaviour
+            const args = rest.trim();
+            if (args && /^[A-Za-z0-9]+$/.test(args)) {
+                return {
+                    type: "chat.unblock",
+                    username: args,
+                }
             }
          }
 
          case "i": {
             const args = rest.split(/^(\S+)\s+/g).filter(s => { return s != ""; });
-            if (args && args.length == 2) {
-                // UNBLOCK behaviour
+            if (args && args.length == 2
+                && /^[A-Za-z0-9]+$/.test(args[0])
+                && (args[1] == "Pong" || args[1] == "ColorWar")) {
+                return {
+                    type: "chat.invite",
+                    username: args[0],
+                    game: args[1],
+                }
             }
          }
-
-           _appendMessage( _createSourceElement("Error"), "Invalid whisper arguments")
 
         default: break;
     };

--- a/srcs/frontend/srcs/js/chat.js
+++ b/srcs/frontend/srcs/js/chat.js
@@ -38,7 +38,11 @@ function connect() {
 
         socket.onopen    = (event) => { console.log('Chat connection opened' , event); _set_disabled(false); };
         socket.onerror   = (event) => { console.log('Chat socket error: ',     event); };
-        socket.onclose   = disconnect;
+        socket.onclose   = () => {
+            socket = null;
+            _set_disabled(true);
+            while (chatLog.lastChild) { chatLog.lastChild.remove(); }
+        };
         socket.onmessage = _messageHandler;
     }
 
@@ -46,9 +50,9 @@ function connect() {
 }
 
 function disconnect() {
-            socket = null;
-            _set_disabled(true);
-            while (chatLog.lastChild) { chatLog.lastChild.remove(); }
+    if (socket) {
+        socket.close()
+    }
 }
 
 function _submitHandler() {
@@ -145,6 +149,7 @@ function _parseInput(input) {
 function _messageHandler(event) {
     try {
         const content = JSON.parse(event.data);
+        console.log("content")
         switch (content.type) {
             case "chat.broadcast": // Same fronted behaviour as whisper, difference being indicated would be nice I guess.
             case "chat.whisper"  : _appendMessage( _createUsernameElement(content.sender), content.message ); break;
@@ -153,7 +158,7 @@ function _messageHandler(event) {
 
             default: throw Error("Unknown chat event");
         }
-    } catch (e) { console.err("Chat message handling failure: ", e); }
+    } catch (e) { console.error("Chat message handling failure: ", e); }
 }
 
 function _set_disabled(isDisabled) {

--- a/srcs/frontend/srcs/js/chat.js
+++ b/srcs/frontend/srcs/js/chat.js
@@ -13,7 +13,7 @@ const helpMessage = "\n" +
                     "/w [username] message - Send a direct message.\n" +
                     "/b [username] - Block user.\n" +
                     "/u [username] - Unblock user.\n" +
-                    "/i [username] [Pong/ColorWar] - Send a game invite.\n";
+                    "/i [username] [Pong/Color] - Send a game invite.\n";
 
 inputField.onkeydown = (e) => { if (e.key === "Enter") { _submitHandler(); e.preventDefault(); } }
 
@@ -124,7 +124,7 @@ function _parseInput(input) {
             const args = rest.split(/^(\S+)\s+/g).filter(s => { return s != ""; });
             if (args && args.length == 2
                 && /^[A-Za-z0-9]+$/.test(args[0])
-                && (args[1] == "Pong" || args[1] == "ColorWar")) {
+                && (args[1] == "Pong" || args[1] == "Color")) {
                 return {
                     type: "chat.invite",
                     username: args[0],

--- a/srcs/frontend/srcs/js/chat.js
+++ b/srcs/frontend/srcs/js/chat.js
@@ -57,7 +57,10 @@ function _submitHandler() {
 
         if (payload) {
             socket.send(JSON.stringify(payload));
+        } else {
+            _appendMessage( _createSourceElement("System"), helpMessage);
         }
+
     } catch (e) {
         console.log("Failed to submit chat message: ", e);
     }
@@ -135,7 +138,6 @@ function _parseInput(input) {
 
         default: break;
     };
-    _appendMessage( _createSourceElement("System"), helpMessage);
     return null;
 }
 

--- a/srcs/frontend/srcs/js/chat.js
+++ b/srcs/frontend/srcs/js/chat.js
@@ -152,7 +152,6 @@ function _parseInput(input) {
 function _messageHandler(event) {
     try {
         const content = JSON.parse(event.data);
-        console.log("content")
         switch (content.type) {
             case "chat.broadcast": // Same fronted behaviour as whisper, difference being indicated would be nice I guess.
             case "chat.whisper"  : _appendMessage( _createUsernameElement(content.sender), content.message ); break;


### PR DESCRIPTION
Implemented chat commands:
- Invite (/i)
- un- and block (/u and /b)

Cleaned up the backend exception handling for related endpoints and decoupled the necessary logic to use from consumer.
Cleaned up chat front-end a bit.

Fixed success message of block not being returned.
Fixed chat help message not printing on some instances of parse errors.